### PR TITLE
Fix color picker translations

### DIFF
--- a/src/editors/index.tsx
+++ b/src/editors/index.tsx
@@ -1,6 +1,6 @@
 import { withTranslator } from 'utils';
 
-import ColorPicker from './ColorPicker';
+import ColorPickerBase from './ColorPicker';
 import EdgeTypeSelect from './EdgeTypeSelect';
 import EntitySelectBase from './EntitySelect';
 import EnumValueSelectBase from './EnumValueSelect';
@@ -15,6 +15,7 @@ const EnumValueSelect = withTranslator(EnumValueSelectBase);
 const PropertyEditor = withTranslator(PropertyEditorBase);
 const PropertySelect = withTranslator(PropertySelectBase);
 const TextEdit = withTranslator(TextEditBase);
+const ColorPicker = withTranslator(ColorPickerBase);
 
 export {
   ColorPicker,


### PR DESCRIPTION
When I added labels for the color picker swatches, I did not wrap the component in an IntlProvider (using withTranslator).

When used in the context of network diagrams, this doesn’t cause bugs, as the network diagram itself is wrapped in an IntlProvider. The bug only surfaced once we upgraded react-ftm in Aleph, as Aleph also uses the color picker component in the timelines UI.

**How to verify this fix:**
1. Check out the latest Aleph and react-ftm releases.

2. Start a new shell session in a UI container and execute the next steps in this shell.
   
   ```
   docker compose -f docker-compose.dev.yml run --name ui_test --service-ports --volume ~/git/react-ftm:/react-ftm ui bash
   ```

3. Install react-ftm dependencies:

   ```
   cd /react-ftm
   npm install
   ```

4. Linking local packages (that have a dependency on React) can result in duplicate versions of React being included in the build. Link React to the Aleph’s `node_modules/react` directory to prevent that. 

   ```
   cd /react-ftm
   npm link /alephui/node_modules/react
   ```

5. Link react-ftm:

   ```
   cd /alephui
   npm link /react-ftm
   ```

6. Build react-ftm

   ```
   cd /react-ftm
   npm run build
   ```

7. Start a React dev server

   ```
   cd /alephui
   PORT=8080 npm start
   ```

8. Open the Aleph UI: http://localhost:8080

9. Create an investigation (or navigate to an existing invesetigation).

10. Create a timeline.

11. Create a new timeline item. When hovering over the color swatches, a tooltip with a text label should be displayed.